### PR TITLE
Update Gemfile to point to https rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "mail", "~> 2.5.3"
 
-gem "htmlentities", "~> 4.3.1"
+gem "htmlentities", "~> 4.3.1"us e


### PR DESCRIPTION
The source :rubygems is deprecated because http requests are insecure, use. https version instead
